### PR TITLE
Use default ssl context

### DIFF
--- a/bitpanda/BitpandaClient.py
+++ b/bitpanda/BitpandaClient.py
@@ -18,13 +18,16 @@ LOG = logging.getLogger(__name__)
 class BitpandaClient(object):
 	REST_API_URI = "https://api.exchange.bitpanda.com/public/v1/"
 
-	def __init__(self, api_key : str = None, api_trace_log : bool = False) -> None:
+	def __init__(self, api_key : str = None, api_trace_log : bool = False, ssl_context : ssl.SSLContext = None) -> None:
 		self.api_key = api_key
 		self.api_trace_log = api_trace_log
 
 		self.rest_session = None
 
-		self.ssl_context = ssl.create_default_context()
+		if ssl_context is not None:
+			self.ssl_context = ssl_context
+		else:
+			self.context = ssl.create_default_context()
 
 		self.subscription_sets = []
 

--- a/bitpanda/BitpandaClient.py
+++ b/bitpanda/BitpandaClient.py
@@ -18,14 +18,13 @@ LOG = logging.getLogger(__name__)
 class BitpandaClient(object):
 	REST_API_URI = "https://api.exchange.bitpanda.com/public/v1/"
 
-	def __init__(self, certificate_path : str = None, api_key : str = None, api_trace_log : bool = False) -> None:
+	def __init__(self, api_key : str = None, api_trace_log : bool = False) -> None:
 		self.api_key = api_key
 		self.api_trace_log = api_trace_log
 
 		self.rest_session = None
 
-		self.ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
-		self.ssl_context.load_verify_locations(certificate_path)
+		self.ssl_context = ssl.create_default_context()
 
 		self.subscription_sets = []
 

--- a/client-example/client.py
+++ b/client-example/client.py
@@ -22,14 +22,11 @@ async def order_book_update(response : dict) -> None:
 async def run():
 	print("STARTING BITPANDA CLIENT\n")
 
-	# to generate a certificate use 'openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 -keyout key.pem -out certificate.pem'
-	certificate_path = pathlib.Path(__file__).with_name("certificate.pem")
-
 	# to retrieve your API key go to your bitpanda global exchange account and store it in BITPANDA_API_KEY environment
 	# variable
 	api_key = os.environ['BITPANDAAPIKEY']
 
-	client = BitpandaClient(certificate_path, api_key)
+	client = BitpandaClient(api_key)
 
 	# REST api calls
 	print("REST API")


### PR DESCRIPTION
Hi!

Great work with the client implementation.

I want to bring a severe problem to your attention. 
The current use of a custom `SSLContext` disables hostname and certificate verification.

Using `ssl.create_default_context()` ensures that the server certificate
is validated when connecting and unsafe ciphers are not accepted.
I verified that the client example works with these changes.

I assume a version bump and changelog entry would be needed too and I'm happy to add these according to your guidance.

Here is a small test script to reproduce the problem with missing server verification.
```
import ssl
import http.client

context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
# context = ssl.create_default_context()

print(f'validates hostnames? {context.check_hostname}')
print(f'verify mode? {context.verify_mode}')

print('connecting to bad host')
h = http.client.HTTPSConnection('wrong.host.badssl.com', context=context)
h.request('GET', '/')
print('connected to bad host')
```

References
* https://docs.python.org/3/library/ssl.html#ssl-security
* https://developers.bitpanda.com/exchange/#authentication