### PR TITLE
Python 3.6.9: time.time_ns() not available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.vscode
+
 # Keys
 *.pem
 

--- a/bitpanda/Timer.py
+++ b/bitpanda/Timer.py
@@ -8,9 +8,11 @@ class Timer(object):
 		self.name = name
 		self.active = active
 
+		self.current_milli_time = lambda: int(round(time.time() * 1000))
+
 	def __enter__(self):
-		self.start_tmstmp = time.time_ns()
+		self.start_tmstmp = self.current_milli_time()
 
 	def __exit__(self, type, value, traceback):
 		if self.active:
-			LOG.debug(f'Timer {self.name} finished. Took {round((time.time_ns() - self.start_tmstmp) / 1000000, 3)} ms.')
+			LOG.debug(f'Timer {self.name} finished. Took {(self.current_milli_time() - self.start_tmstmp)} ms.')


### PR DESCRIPTION
['time.time_ns()' method is new in Python version 3.7 ](https://www.geeksforgeeks.org/python-time-time_ns-method/).
Therefore, testing in Python 3.6 resulted in an error message, stating that the module 'time' has no attribute 'time_ns()'.
As your Timer module only displays ms, I changed the code, so that it can be used in Python 3.6.

This issues occurred in a Colab VM and the fix has been successfully tested there.

Additionally, I added the vscode directory to the gitignore for obvious dev. purposes.